### PR TITLE
Consider a mechanism for supporting 3rd party plugins

### DIFF
--- a/bin/styl
+++ b/bin/styl
@@ -4,6 +4,8 @@
  * Module dependencies.
  */
 
+var fs = require('fs');
+var path = require('path');
 var program = require('commander');
 var pkg = require('../package.json');
 var stdin = require('stdin');
@@ -17,6 +19,16 @@ program
   .option('-w, --whitespace', 'use significant whitespace pre-processor')
   .option('-c, --compress', 'use output compression')
   .parse(process.argv);
+
+// plugins
+
+var plugins;
+
+try {
+  plugins = require(path.join(process.cwd(), 'plugins'));
+} catch (nothing) {  // fail silently
+  plugins = [];
+}
 
 // prefixes
 
@@ -32,5 +44,8 @@ stdin(function(str){
   options.compress = program.compress;
   var style = new Style(str, options);
   style.vendors(vendors);
+  plugins.forEach(function(plugin) {
+    style.use(plugin);
+  });
   process.stdout.write(style.toString());
 });

--- a/examples/plugins.js
+++ b/examples/plugins.js
@@ -1,0 +1,7 @@
+var rework = require('rework');
+var variant = require('rework-variant');
+
+module.exports = [
+  variant(),
+  require('autoprefixer').rework()
+];


### PR DESCRIPTION
A great part of Rework/Styl is being able to extend it through plugins. While this is possible programically you can't use the same method from the command line.

This would allow you to specify plugins to use in a file. That gives you an easy spot to edit them and allows you to manage them in version control. Being a Javascript file, it also allows you a place to initialize and configure them.

<!-- Reviewable:start -->

[<img src="https://reviewable.io/review_button.png" height=40 alt="Review on Reviewable"/>](https://reviewable.io/reviews/tj/styl/14)

<!-- Reviewable:end -->
