### PR TITLE
use autoprefixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@
  * Module dependencies.
  */
 
+var autoprefixer = require('autoprefixer');
 var whitespace = require('css-whitespace');
 var mixins = require('rework-mixins');
 var rework = require('rework');
@@ -34,8 +35,8 @@ function Style(str, options) {
   this.str = str;
   this.compress = options.compress;
   this.rework = rework(str);
+  this.browsers = options.browsers;
   this.delegate(['vendors', 'use']);
-  this.vendors(['-ms-', '-moz-', '-webkit-']);
 }
 
 /**
@@ -61,15 +62,11 @@ Style.prototype.delegate = function(methods){
 
 Style.prototype.toString = function(){
   this.use(rework.mixin(mixins));
-  this.use(rework.keyframes());
   this.use(rework.ease());
-  this.use(rework.prefixValue('linear-gradient'));
-  this.use(rework.prefixValue('radial-gradient'));
-  this.use(rework.prefixValue('transform'));
-  this.use(rework.prefix(props));
   this.use(rework.colors());
   this.use(rework.references());
   this.use(rework.at2x());
   this.use(rework.extend());
+  this.use(autoprefixer(this.browsers).rework);
   return this.rework.toString({ compress: this.compress });
 };

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "rework": "0.18.3",
     "commander": "1.1.1",
     "stdin": "0.0.1",
-    "rework-mixins": "1.1.1"
+    "rework-mixins": "1.1.1",
+    "autoprefixer": "~0.8.20131213"
   },
   "devDependencies": {
     "should": "~1.2.2",

--- a/test/cases/ease.out.css
+++ b/test/cases/ease.out.css
@@ -1,6 +1,4 @@
 body {
-  -ms-transition: 200ms cubic-bezier(0.680, -0.550, 0.265, 1.550);
-  -moz-transition: 200ms cubic-bezier(0.680, -0.550, 0.265, 1.550);
   -webkit-transition: 200ms cubic-bezier(0.680, -0.550, 0.265, 1.550);
   transition: 200ms cubic-bezier(0.680, -0.550, 0.265, 1.550);
 }

--- a/test/cases/keyframes.out.css
+++ b/test/cases/keyframes.out.css
@@ -1,34 +1,14 @@
-@keyframes fade {
-  from {
-    width: 50px;
-  }
-
-  to {
-    height: 50px;
-  }
-}
-
-@-ms-keyframes fade {
-  from {
-    width: 50px;
-  }
-
-  to {
-    height: 50px;
-  }
-}
-
-@-moz-keyframes fade {
-  from {
-    width: 50px;
-  }
-
-  to {
-    height: 50px;
-  }
-}
-
 @-webkit-keyframes fade {
+  from {
+    width: 50px;
+  }
+
+  to {
+    height: 50px;
+  }
+}
+
+@keyframes fade {
   from {
     width: 50px;
   }

--- a/test/cases/keyframes.prefixes.out.css
+++ b/test/cases/keyframes.prefixes.out.css
@@ -1,37 +1,3 @@
-@keyframes animate {
-  from {
-    transform: rotateX(0);
-  }
-
-  to {
-    transform: rotateX(150deg);
-  }
-}
-
-@-ms-keyframes animate {
-  from {
-    -ms-transform: rotateX(0);
-    transform: rotateX(0);
-  }
-
-  to {
-    -ms-transform: rotateX(150deg);
-    transform: rotateX(150deg);
-  }
-}
-
-@-moz-keyframes animate {
-  from {
-    -moz-transform: rotateX(0);
-    transform: rotateX(0);
-  }
-
-  to {
-    -moz-transform: rotateX(150deg);
-    transform: rotateX(150deg);
-  }
-}
-
 @-webkit-keyframes animate {
   from {
     -webkit-transform: rotateX(0);
@@ -40,6 +6,20 @@
 
   to {
     -webkit-transform: rotateX(150deg);
+    transform: rotateX(150deg);
+  }
+}
+
+@keyframes animate {
+  from {
+    -webkit-transform: rotateX(0);
+    -ms-transform: rotateX(0);
+    transform: rotateX(0);
+  }
+
+  to {
+    -webkit-transform: rotateX(150deg);
+    -ms-transform: rotateX(150deg);
     transform: rotateX(150deg);
   }
 }

--- a/test/cases/prefix-values.out.css
+++ b/test/cases/prefix-values.out.css
@@ -1,6 +1,5 @@
 button {
-  background: -ms-linear-gradient(top, black, white);
-  background: -moz-linear-gradient(top, black, white);
+  background: -webkit-gradient(linear, left top, left bottom, from(black), to(white));
   background: -webkit-linear-gradient(top, black, white);
   background: linear-gradient(top, black, white);
 }


### PR DESCRIPTION
since rework is removing vendor prefix support. autoprefixer is not pinned because `patch`s are just caniuse db updates. 

didn't update the readme - theres `.browsers` option. tests pass (travis maybe?). maybe remove `.delegate` and `.vendors()`.
